### PR TITLE
見出しコンポーネント作成

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -13,7 +13,7 @@
     <div class="hero-grid__news"><app-news></app-news></div>
   </div>
   <div class="container">
-    <app-heading [title]="'Treading'"></app-heading>
+    <app-heading>Treading</app-heading>
 
     <div class="trend-grid">
       <div class="placeholder">card-middle</div>
@@ -21,7 +21,7 @@
       <div class="placeholder">card-middle</div>
     </div>
 
-    <app-heading [title]="'Happening Now'"></app-heading>
+    <app-heading>Happening Now</app-heading>
 
     <div class="now-grid">
       <div class="card-grid">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -13,7 +13,7 @@
     <div class="hero-grid__news"><app-news></app-news></div>
   </div>
   <div class="container">
-    <h2 class="placeholder">TRENDING</h2>
+    <app-heading [title]="'Treading'"></app-heading>
 
     <div class="trend-grid">
       <div class="placeholder">card-middle</div>
@@ -21,7 +21,7 @@
       <div class="placeholder">card-middle</div>
     </div>
 
-    <h2 class="placeholder">HAPPENING NOW</h2>
+    <app-heading [title]="'Happening Now'"></app-heading>
 
     <div class="now-grid">
       <div class="card-grid">

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,12 +6,14 @@ import { AppComponent } from './app.component';
 import { NewsComponent } from './news/news.component';
 
 import { BreadListComponent } from './bread-list/bread-list.component';
+import { HeadingComponent } from './heading/heading.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     BreadListComponent,
-    NewsComponent
+    NewsComponent,
+    HeadingComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/heading/heading.component.html
+++ b/src/app/heading/heading.component.html
@@ -1,0 +1,15 @@
+<div class="heading">
+  <h2 class="heading__title">{{ title }}</h2>
+  <div class="heading__nav">
+    <a href="#" class="heading__prev disabled">
+      <svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10">
+        <path d="M5,6a.908.908,0,0,1-.7-.3l-4-4A.967.967,0,0,1,.3.3.967.967,0,0,1,1.7.3L5,3.6,8.3.3A.967.967,0,0,1,9.7.3a.967.967,0,0,1,0,1.4l-4,4A.908.908,0,0,1,5,6Z" transform="translate(6) rotate(90)"/>
+      </svg>
+    </a>
+    <a href="#" class="heading__next">
+      <svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10">
+        <path d="M5,6a.908.908,0,0,1-.7-.3l-4-4A.967.967,0,0,1,.3.3.967.967,0,0,1,1.7.3L5,3.6,8.3.3A.967.967,0,0,1,9.7.3a.967.967,0,0,1,0,1.4l-4,4A.908.908,0,0,1,5,6Z" transform="translate(0 10) rotate(-90)"/>
+      </svg>
+    </a>
+  </div>
+</div>

--- a/src/app/heading/heading.component.html
+++ b/src/app/heading/heading.component.html
@@ -1,5 +1,5 @@
 <div class="heading">
-  <h2 class="heading__title">{{ title }}</h2>
+  <h2 class="heading__title"><ng-content></ng-content></h2>
   <div class="heading__nav">
     <a href="#" class="heading__prev disabled">
       <svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10">

--- a/src/app/heading/heading.component.scss
+++ b/src/app/heading/heading.component.scss
@@ -1,0 +1,42 @@
+.heading {
+  margin: 40px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #202124;
+
+  &__title {
+    margin: 0;
+    font-size: 24px;
+    font-weight: bold;
+    line-height: calc( 20 / 24 );
+    text-transform: uppercase;
+  }
+  &__nav {
+    display: flex;
+  }
+  &__prev,
+  &__next {
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    path {
+      fill: #202124;
+      transition: fill .4s;
+    }
+    &.disabled {
+      opacity: .3;
+      pointer-events: none;
+    }
+    &:not(.disabled):hover {
+      path {
+        fill: #FA6980;
+      }
+    }
+  }
+  &__prev {
+    margin-right: 18px;
+  }
+}

--- a/src/app/heading/heading.component.scss
+++ b/src/app/heading/heading.component.scss
@@ -14,6 +14,7 @@
   }
   &__nav {
     display: flex;
+    margin-right: -7px;
   }
   &__prev,
   &__next {

--- a/src/app/heading/heading.component.scss
+++ b/src/app/heading/heading.component.scss
@@ -3,6 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   color: #202124;
 
   &__title {
@@ -14,6 +15,7 @@
   }
   &__nav {
     display: flex;
+    margin-left: auto;
     margin-right: -7px;
   }
   &__prev,

--- a/src/app/heading/heading.component.spec.ts
+++ b/src/app/heading/heading.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HeadingComponent } from './heading.component';
+
+describe('HeadingComponent', () => {
+  let component: HeadingComponent;
+  let fixture: ComponentFixture<HeadingComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ HeadingComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HeadingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/heading/heading.component.ts
+++ b/src/app/heading/heading.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-heading',
+  templateUrl: './heading.component.html',
+  styleUrls: ['./heading.component.scss']
+})
+export class HeadingComponent implements OnInit {
+
+  constructor() { }
+
+  @Input() title: string;
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/heading/heading.component.ts
+++ b/src/app/heading/heading.component.ts
@@ -9,8 +9,6 @@ export class HeadingComponent implements OnInit {
 
   constructor() { }
 
-  @Input() title: string;
-
   ngOnInit(): void {
   }
 


### PR DESCRIPTION
見出しのマークアップを行いました。
ご確認よろしくお願い致します。

## スクリーンショット

![heading_treading](https://user-images.githubusercontent.com/46749854/88533155-bf0ce880-d040-11ea-965c-18eb17572ea8.png)

![heading_happening_now](https://user-images.githubusercontent.com/46749854/88533170-caf8aa80-d040-11ea-9eda-032ab3220b56.png)

## 特記事項
下記について、ご検討お願い致します。

### ページネーションについて

#### ユーザビリティ
アイコンの領域をそのままリンクの領域にしてしまうとユーザビリティを損ねるので、リンク領域はアイコンを中心に縦横20px持たせました。 デザインカンプでは、nextのアイコンがcontainerの右端に揃っているのですが、この実装によってアイコンの位置が、デザインより7pxほど内側に寄ってしまいます。こちらについて、デザインに忠実に再現する方がよければ位置調整を行いますので、お申し付けください。
<img width="651" alt="heading_xd" src="https://user-images.githubusercontent.com/46749854/88533351-25920680-d041-11ea-9739-f295d0b9ca6e.png">
<img width="498" alt="heading_browser" src="https://user-images.githubusercontent.com/46749854/88533364-29be2400-d041-11ea-82bc-d11c4ab7b3a1.png">


#### ホバーアニメーション
ホバーの指示は特になかったと思うので、一旦サイトのアクセントカラー（#FA6980）への切替にて対応しております。

#### 非活性時の処理
初期値でprevのリンクは非活性かと思いますので、class名"disabled"を付与しました。
非活性の処理は、CSS側で行っております。