### PR TITLE
headerの修正（font-familyを指定）

### DIFF
--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -1,6 +1,10 @@
 $color-base: #F6F8F9;
 $color-accent: #FA6980;
 
+:host {
+  font-family: Helvetica, Arial, sans-serif;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -49,6 +53,7 @@ a {
   &__logo {
     margin: 0;
     color: $color-accent;
+    font-family: 'Acumin Pro', Helvetica, Arial, sans-serif;
     font-size: 13px;
     font-weight: bold;
     line-height: calc( 20 / 13 );


### PR DESCRIPTION
fix #2 

## Todo
header領域、ロゴにfont-familyを指定しました。

- [x] 表示確認をした（スマホ、PC）

## スクリーンショット
![localhost_4200_ (1)](https://user-images.githubusercontent.com/46749854/90506958-07c34780-e190-11ea-9330-e6bca17fb8e0.png)
